### PR TITLE
Add tests to `ReviewsViewController` menu bar button item behaviour

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,7 @@
 - [**] Product SKU input scanner is now available as a beta feature. To try it, enable it from settings and you can scan a barcode to use as the product SKU in product inventory settings! [https://github.com/woocommerce/woocommerce-ios/pull/5695]
 - [**] Now you chan share a payment link when creating a Simple Payments order [https://github.com/woocommerce/woocommerce-ios/pull/5819]
 - [*] Reviews: "Mark all as read" checkmark bar button item button replaced with menu button which launches an action sheet. Menu button is displayed only if there are unread reviews available.[https://github.com/woocommerce/woocommerce-ios/pull/5833]
+- [internal] Refactored ReviewsViewController to add tests. [https://github.com/woocommerce/woocommerce-ios/pull/5834]
 
 8.2
 -----

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewController.swift
@@ -6,7 +6,7 @@ import SafariServices.SFSafariViewController
 //
 final class ReviewsViewController: UIViewController {
 
-    private let siteID: Int64
+    typealias ViewModel = ReviewsViewModelOutput & ReviewsViewModelActionsHandler
 
     /// Main TableView.
     ///
@@ -26,7 +26,7 @@ final class ReviewsViewController: UIViewController {
         return item
     }()
 
-    private let viewModel: ReviewsViewModel
+    private let viewModel: ViewModel
 
     /// Haptic Feedback!
     ///
@@ -111,11 +111,15 @@ final class ReviewsViewController: UIViewController {
                                               })
     }()
 
-    // MARK: - View Lifecycle
+    // MARK: - Initializers
+    //
+    convenience init(siteID: Int64) {
+        self.init(viewModel: ReviewsViewModel(siteID: siteID,
+                                              data: DefaultReviewsDataSource(siteID: siteID)))
+    }
 
-    init(siteID: Int64) {
-        self.siteID = siteID
-        self.viewModel = ReviewsViewModel(siteID: siteID, data: DefaultReviewsDataSource(siteID: siteID))
+    init(viewModel: ViewModel) {
+        self.viewModel = viewModel
 
         super.init(nibName: nil, bundle: nil)
 
@@ -127,6 +131,8 @@ final class ReviewsViewController: UIViewController {
         fatalError("init(coder:) has not been implemented")
     }
 
+    // MARK: - View Lifecycle
+    //
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .listBackground

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewController.swift
@@ -157,7 +157,7 @@ final class ReviewsViewController: UIViewController {
             syncingCoordinator.resynchronize()
         }
 
-        if AppRatingManager.shared.shouldPromptForAppReview(section: Constants.section) {
+        if viewModel.shouldPromptForAppReview {
             displayRatingPrompt()
         }
 
@@ -614,10 +614,6 @@ private extension ReviewsViewController {
         case emptyUnfiltered
         case results
         case syncing(pageNumber: Int)
-    }
-
-    struct Constants {
-        static let section = "notifications"
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewModel.swift
@@ -14,6 +14,8 @@ protocol ReviewsViewModelOutput {
 
     var hasUnreadNotifications: Bool { get }
 
+    var shouldPromptForAppReview: Bool { get }
+
     var hasErrorLoadingData: Bool { get set }
 
     func containsMorePages(_ highestVisibleReview: Int) -> Bool
@@ -60,6 +62,10 @@ final class ReviewsViewModel: ReviewsViewModelOutput, ReviewsViewModelActionsHan
 
     private var unreadNotifications: [Note] {
         return data.notifications.filter { $0.read == false }
+    }
+
+    var shouldPromptForAppReview: Bool {
+        AppRatingManager.shared.shouldPromptForAppReview(section: Constants.section)
     }
 
     /// Set when sync fails, and used to display an error loading data banner
@@ -232,5 +238,9 @@ private extension ReviewsViewModel {
         static let placeholderRowsPerSection = [3]
         static let firstPage = 1
         static let pageSize = 25
+    }
+
+    struct Constants {
+        static let section = "notifications"
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewModel.swift
@@ -5,8 +5,39 @@ import Yosemite
 
 import class AutomatticTracks.CrashLogging
 
+protocol ReviewsViewModelOutput {
+    var isEmpty: Bool { get }
 
-final class ReviewsViewModel {
+    var dataSource: UITableViewDataSource { get }
+
+    var delegate: ReviewsInteractionDelegate { get }
+
+    var hasUnreadNotifications: Bool { get }
+
+    var hasErrorLoadingData: Bool { get set }
+
+    func containsMorePages(_ highestVisibleReview: Int) -> Bool
+}
+
+protocol ReviewsViewModelActionsHandler {
+    func displayPlaceholderReviews(tableView: UITableView)
+
+    func removePlaceholderReviews(tableView: UITableView)
+
+    func configureResultsController(tableView: UITableView)
+
+    func refreshResults()
+
+    func configureTableViewCells(tableView: UITableView)
+
+    func markAllAsRead(onCompletion: @escaping (Error?) -> Void)
+
+    func synchronizeReviews(pageNumber: Int,
+                            pageSize: Int,
+                            onCompletion: (() -> Void)?)
+}
+
+final class ReviewsViewModel: ReviewsViewModelOutput, ReviewsViewModelActionsHandler {
     private let siteID: Int64
 
     private let data: ReviewsDataSource
@@ -93,9 +124,9 @@ final class ReviewsViewModel {
 extension ReviewsViewModel {
     /// Prepares data necessary to render the reviews tab.
     ///
-    func synchronizeReviews(pageNumber: Int = Settings.firstPage,
-                            pageSize: Int = Settings.pageSize,
-                            onCompletion: (() -> Void)? = nil) {
+    func synchronizeReviews(pageNumber: Int,
+                            pageSize: Int,
+                            onCompletion: (() -> Void)?) {
         hasErrorLoadingData = false
 
         let group = DispatchGroup()

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1120,6 +1120,7 @@
 		B6E851F5276330200041D1BA /* RefundFeesDetailsTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6E851F4276330200041D1BA /* RefundFeesDetailsTableViewCell.swift */; };
 		B6E851F7276331110041D1BA /* RefundFeesDetailsTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = B6E851F6276331110041D1BA /* RefundFeesDetailsTableViewCell.xib */; };
 		B873E8F8E103966D2182EE67 /* Pods_WooCommerceTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6DC4526F9A7357761197EBF0 /* Pods_WooCommerceTests.framework */; };
+		BAA34C202787494300846F3C /* ReviewsViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAA34C1F2787494300846F3C /* ReviewsViewControllerTests.swift */; };
 		BAE4F8432734325C00871344 /* SettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAE4F8422734325C00871344 /* SettingsViewModel.swift */; };
 		BAFEF51E273C2151005F94CC /* SettingsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAFEF51D273C2151005F94CC /* SettingsViewModelTests.swift */; };
 		CC0324A3263AD9F40056C6B7 /* MockShippingLabelAccountSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0324A2263AD9F40056C6B7 /* MockShippingLabelAccountSettings.swift */; };
@@ -2694,6 +2695,7 @@
 		B6E851F2276320C70041D1BA /* RefundFeesDetailsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundFeesDetailsViewModel.swift; sourceTree = "<group>"; };
 		B6E851F4276330200041D1BA /* RefundFeesDetailsTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundFeesDetailsTableViewCell.swift; sourceTree = "<group>"; };
 		B6E851F6276331110041D1BA /* RefundFeesDetailsTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = RefundFeesDetailsTableViewCell.xib; sourceTree = "<group>"; };
+		BAA34C1F2787494300846F3C /* ReviewsViewControllerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReviewsViewControllerTests.swift; sourceTree = "<group>"; };
 		BABE5E07DD787ECA6D2A76DE /* Pods_WooCommerce.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_WooCommerce.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BAE4F8422734325C00871344 /* SettingsViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsViewModel.swift; sourceTree = "<group>"; };
 		BAFEF51D273C2151005F94CC /* SettingsViewModelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsViewModelTests.swift; sourceTree = "<group>"; };
@@ -6045,6 +6047,14 @@
 			path = Settings;
 			sourceTree = "<group>";
 		};
+		BAA34C1E2787494300846F3C /* Reviews */ = {
+			isa = PBXGroup;
+			children = (
+				BAA34C1F2787494300846F3C /* ReviewsViewControllerTests.swift */,
+			);
+			path = Reviews;
+			sourceTree = "<group>";
+		};
 		BAF1B3B32736595A00BA11DC /* Settings */ = {
 			isa = PBXGroup;
 			children = (
@@ -6918,6 +6928,7 @@
 		D816DDBA22265D8000903E59 /* ViewRelated */ = {
 			isa = PBXGroup;
 			children = (
+				BAA34C1E2787494300846F3C /* Reviews */,
 				03FBDAF7263EE49300ACE257 /* Coupons */,
 				BA143222273662DE00E4B3AB /* Settings */,
 				D449C52A26E02EFD00D75B02 /* WhatsNew */,
@@ -8881,6 +8892,7 @@
 				5761298B24589B84007BB2D9 /* NumberFormatter+LocalizedOrNinetyNinePlusTests.swift in Sources */,
 				2667BFD7252E5DBF008099D4 /* RefundItemViewModelTests.swift in Sources */,
 				7435E59021C0162C00216F0F /* OrderNoteWooTests.swift in Sources */,
+				BAA34C202787494300846F3C /* ReviewsViewControllerTests.swift in Sources */,
 				02CE43092769953D0006EAEF /* MockCaptureDevicePermissionChecker.swift in Sources */,
 				7E6A01A32726C5D3001668D5 /* MockProductCategoryStoresManager.swift in Sources */,
 				45F5A3C323DF31D2007D40E5 /* ShippingInputFormatterTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Reviews/ReviewsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Reviews/ReviewsViewModelTests.swift
@@ -66,7 +66,7 @@ final class ReviewsViewModelTests: XCTestCase {
 
         let expec = expectation(description: "Wait for synchronizeReviews to complete")
 
-        viewModel.synchronizeReviews {
+        viewModel.synchronizeReviews(pageNumber: 1, pageSize: 25) {
             let allTargetsHit = storesManager.syncReviewsIsHit && storesManager.retrieveProductsIsHit
             XCTAssertTrue(allTargetsHit)
             if allTargetsHit {
@@ -86,7 +86,7 @@ final class ReviewsViewModelTests: XCTestCase {
         ServiceLocator.setStores(storesManager)
 
         // When
-        viewModel.synchronizeReviews()
+        viewModel.synchronizeReviews(pageNumber: 1, pageSize: 25, onCompletion: nil)
 
         // Then
         XCTAssertFalse(viewModel.hasErrorLoadingData)
@@ -107,7 +107,7 @@ final class ReviewsViewModelTests: XCTestCase {
         ServiceLocator.setStores(storesManager)
 
         // When
-        viewModel.synchronizeReviews()
+        viewModel.synchronizeReviews(pageNumber: 1, pageSize: 25, onCompletion: nil)
 
         // Then
         XCTAssertTrue(viewModel.hasErrorLoadingData)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Reviews/ReviewsViewControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Reviews/ReviewsViewControllerTests.swift
@@ -1,0 +1,101 @@
+import XCTest
+@testable import WooCommerce
+
+/// Tests for `ReviewsViewController`.
+///
+final class ReviewsViewControllerTests: XCTestCase {
+    private var mockViewModel: MockReviewsViewModel!
+    private var sut: ReviewsViewController!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        mockViewModel = MockReviewsViewModel(siteID: 123)
+        sut = ReviewsViewController(viewModel: mockViewModel)
+    }
+
+    override func tearDownWithError() throws {
+        mockViewModel = nil
+        sut = nil
+
+        try super.tearDownWithError()
+    }
+
+    func test_menu_bar_button_item_is_not_present_if_there_are_no_unread_notifications() {
+        // When
+        mockViewModel.hasUnreadNotifications = false
+        sut.makeViewAppear()
+
+        // Then
+        XCTAssertNil(sut.navigationItem.rightBarButtonItem)
+    }
+
+    func test_menu_bar_button_item_is_visible_if_there_are_unread_notifications_available() throws {
+        // When
+        mockViewModel.hasUnreadNotifications = true
+        sut.makeViewAppear()
+
+        // Then
+        let markAllAsReadyButton = try XCTUnwrap(sut.navigationItem.rightBarButtonItem)
+        XCTAssertEqual(markAllAsReadyButton.accessibilityIdentifier, "reviews-open-menu-button")
+    }
+}
+
+// MARK: ReviewsViewController helpers
+//
+private extension ReviewsViewController {
+    func makeViewAppear() {
+        loadViewIfNeeded()
+        beginAppearanceTransition(true, animated: false)
+        endAppearanceTransition()
+    }
+}
+
+// MARK: Mocks
+//
+private final class MockReviewsViewModel: ReviewsViewModelOutput, ReviewsViewModelActionsHandler {
+
+    private let data: ReviewsDataSource
+
+    init(siteID: Int64) {
+        self.data = DefaultReviewsDataSource(siteID: siteID)
+    }
+
+    // `ReviewsViewModelOutput` conformance
+    //
+    var isEmpty: Bool {
+        data.isEmpty
+    }
+
+    var dataSource: UITableViewDataSource {
+        data
+    }
+
+    var delegate: ReviewsInteractionDelegate {
+        data
+    }
+
+    var hasUnreadNotifications = true
+
+    var shouldPromptForAppReview = false
+
+    var hasErrorLoadingData = true
+
+    func containsMorePages(_ highestVisibleReview: Int) -> Bool { false }
+
+    // Empty methods for `ReviewsViewModelActionsHandler` conformance
+    //
+    func displayPlaceholderReviews(tableView: UITableView) {}
+
+    func removePlaceholderReviews(tableView: UITableView) {}
+
+    func configureResultsController(tableView: UITableView) {}
+
+    func refreshResults() {}
+
+    func configureTableViewCells(tableView: UITableView) {}
+
+    func markAllAsRead(onCompletion: @escaping (Error?) -> Void) {}
+
+    func synchronizeReviews(pageNumber: Int, pageSize: Int, onCompletion: (() -> Void)?) {}
+}


### PR DESCRIPTION

<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR aims to add tests to ensure that the menu `rightBarButtonItem` in `ReviewsViewController` is displayed only when there are unread reviews/notifications available. 

The following changes have been made in order to achieve that,

- Replace `ReviewsViewModel` with `ReviewsViewModelOutput` and `ReviewsViewModelActionsHandler` protocols.
- Introduce convenience initializer for `ReviewsViewController` to add ability to inject ViewModel from tests.
- Remove default params from `func synchronizeReviews` as they are only needed inside tests. Update the method calls from `ReviewsViewModelTests` accordingly.
- Introduce `shouldPromptForAppReview` property in `ReviewsViewModelOutput` to avoid accessing `AppRatingManager` singleton from `ReviewsViewController`
- Finally, create `ReviewsViewControllerTests` and test bar button item behaviour.

### Testing instructions
Smoke test the Reviews screen to ensure that this refactor doesn't break anything.

---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
